### PR TITLE
Fix SDK text limit (999 bytes), raise tool preview limits, fix hook auth

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,9 +9,10 @@
             "url": "http://127.0.0.1:8787/api/hooks/permission-request",
             "timeout": 310,
             "headers": {
-              "X-Tmux-Target": "$CC_G2_TMUX_TARGET"
+              "X-Tmux-Target": "$CC_G2_TMUX_TARGET",
+              "X-CC-G2-Token": "$HUB_AUTH_TOKEN"
             },
-            "allowedEnvVars": ["CC_G2_TMUX_TARGET"]
+            "allowedEnvVars": ["CC_G2_TMUX_TARGET", "HUB_AUTH_TOKEN"]
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 dist/
 tmp/
 plan/
+CLAUDE.md
 
 # Local env (Vite)
 .env
@@ -11,3 +12,7 @@ plan/
 
 # Claude Code local settings
 .claude/settings.local.json
+.claude/skills/
+
+# Local agents / skills
+.agents/

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "voice-entry:dev": "node server/voice-entry/index.mjs",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run test/even-events.test.ts test/format-and-wav.test.ts test/hub-approval-api.test.mjs test/hub-hook-endpoint.test.mjs test/voice-entry.test.mjs",
+    "test": "vitest run test/even-events.test.ts test/format-and-wav.test.ts test/paginate-text.test.ts test/hub-approval-api.test.mjs test/hub-hook-endpoint.test.mjs test/voice-entry.test.mjs",
     "test:all": "vitest run",
     "test:watch": "vitest"
   },

--- a/scripts/cc-g2.sh
+++ b/scripts/cc-g2.sh
@@ -356,6 +356,28 @@ run_internal_command() {
       fi
       exit 0
       ;;
+    find-session)
+      local work_dir=""
+      while [ $# -gt 0 ]; do
+        case "$1" in
+          --workdir) work_dir="$2"; shift 2 ;;
+          *) error "Unknown find-session arg: $1"; exit 1 ;;
+        esac
+      done
+      [ -n "$work_dir" ] || { error "find-session requires --workdir"; exit 1; }
+      local base_name
+      base_name="$(make_tmux_session_name "$work_dir")"
+      # Pick the latest session matching base_name (highest suffix wins)
+      local found=""
+      found=$(tmux list-sessions -F '#{session_name}' 2>/dev/null \
+        | grep "^${base_name}\(-[0-9]*\)\{0,1\}$" | sort -V | tail -1)
+      if [ -n "$found" ]; then
+        json_out --arg sessionName "$found" '{ok:true,exists:true,sessionName:$sessionName}'
+      else
+        json_out '{ok:true,exists:false}'
+      fi
+      exit 0
+      ;;
   esac
 }
 

--- a/server/notification-hub/approval-ui.html
+++ b/server/notification-hub/approval-ui.html
@@ -100,11 +100,11 @@ function render() {
         detail += '\n\n$ ' + a.toolInput.command;
       } else if (a.toolInput.file_path) {
         detail += '\nFile: ' + a.toolInput.file_path;
-        if (a.toolInput.old_string) detail += '\n\n--- old ---\n' + a.toolInput.old_string.slice(0, 500);
-        if (a.toolInput.new_string) detail += '\n--- new ---\n' + a.toolInput.new_string.slice(0, 500);
-        if (a.toolInput.content) detail += '\n\n' + a.toolInput.content.slice(0, 500);
+        if (a.toolInput.old_string) detail += '\n\n--- old ---\n' + a.toolInput.old_string.slice(0, 2000);
+        if (a.toolInput.new_string) detail += '\n--- new ---\n' + a.toolInput.new_string.slice(0, 2000);
+        if (a.toolInput.content) detail += '\n\n' + a.toolInput.content.slice(0, 2000);
       } else {
-        detail += '\n\n' + JSON.stringify(a.toolInput, null, 2).slice(0, 500);
+        detail += '\n\n' + JSON.stringify(a.toolInput, null, 2).slice(0, 2000);
       }
     }
 

--- a/server/notification-hub/index.mjs
+++ b/server/notification-hub/index.mjs
@@ -597,15 +597,15 @@ function buildToolPreview(toolName, toolInput) {
     return toolInput?.command || ''
   } else if (toolName === 'Edit') {
     const file = toolInput?.file_path || ''
-    const old = (toolInput?.old_string || '').slice(0, 200)
-    const new_ = (toolInput?.new_string || '').slice(0, 200)
+    const old = (toolInput?.old_string || '').slice(0, 2000)
+    const new_ = (toolInput?.new_string || '').slice(0, 2000)
     return `${file}\n--- old ---\n${old}\n+++ new +++\n${new_}`
   } else if (toolName === 'Write') {
     const file = toolInput?.file_path || ''
-    const content = (toolInput?.content || '').slice(0, 300)
+    const content = (toolInput?.content || '').slice(0, 2000)
     return `${file}\n${content}`
   } else {
-    return JSON.stringify(toolInput || {}).slice(0, 300)
+    return JSON.stringify(toolInput || {}).slice(0, 2000)
   }
 }
 

--- a/server/voice-entry/index.mjs
+++ b/server/voice-entry/index.mjs
@@ -568,6 +568,16 @@ async function sessionExists(sessionName) {
   }
 }
 
+async function findSessionForWorkdir(workdir) {
+  if (!workdir) return null
+  try {
+    const result = await runCcG2Command(['find-session', '--workdir', workdir])
+    return result?.exists ? result.sessionName : null
+  } catch {
+    return null
+  }
+}
+
 function launchCcG2Session(prompt, workdir) {
   return runCcG2Command(['launch-detached', '--workdir', workdir, '--prompt', prompt])
 }
@@ -692,25 +702,25 @@ const server = http.createServer((req, res) => {
 
       if (VOICE_ENTRY_MODE === 'session-entry') {
         const target = await resolveLaunchTarget(userText)
-        const lastSession = readLastSession()
-        let canContinue =
-          target.mode === 'continue_latest' &&
-          lastSession &&
-          typeof lastSession.sessionName === 'string' &&
-          typeof lastSession.workdir === 'string' &&
-          (await sessionExists(lastSession.sessionName))
+
+        // continue_latest: find an existing session for the selector-chosen workdir
+        let continueSessionName = null
+        if (target.mode === 'continue_latest') {
+          continueSessionName = await findSessionForWorkdir(target.workdir)
+        }
 
         let launch
-        if (canContinue) {
+        let canContinue = false
+        if (continueSessionName) {
           try {
-            launch = await continueCcG2Session(target.prompt, lastSession.sessionName)
+            launch = await continueCcG2Session(target.prompt, continueSessionName)
+            canContinue = true
           } catch (error) {
-            canContinue = false
             appendLog({
               type: 'session_continue_error',
               userText,
               message: error instanceof Error ? error.message : String(error),
-              sessionName: lastSession.sessionName,
+              sessionName: continueSessionName,
             })
           }
         }
@@ -718,10 +728,10 @@ const server = http.createServer((req, res) => {
           launch = await launchCcG2Session(target.prompt, target.workdir)
         }
 
-        const effectiveWorkdir = canContinue ? lastSession.workdir : target.workdir
-        const effectiveSessionName = launch.sessionName || lastSession?.sessionName || ''
+        const effectiveWorkdir = target.workdir
+        const effectiveSessionName = launch.sessionName || continueSessionName || ''
         const content = canContinue
-          ? `直前のClaude Codeセッションに続けて依頼しました。作業場所は ${path.basename(effectiveWorkdir)} です。結果はG2通知で返ります。`
+          ? `既存のClaude Codeセッションに続けて依頼しました。作業場所は ${path.basename(effectiveWorkdir)} です。結果はG2通知で返ります。`
           : `新しいClaude Codeセッションを開始しました。作業場所は ${path.basename(effectiveWorkdir)} です。結果はG2通知で返ります。`
 
         writeLastSession({

--- a/src/glasses-ui.ts
+++ b/src/glasses-ui.ts
@@ -39,21 +39,51 @@ export type NotificationUIState = {
   replyText: string
 }
 
-/** G2表示用: fullTextをページ分割する（約6行×22文字/行 ≒ 132文字/ページ） */
-function paginateText(text: string, charsPerPage = 130): string[] {
-  if (!text) return ['（本文なし）']
+/**
+ * G2表示用: fullTextをチャンク分割する（UTF-8バイト数基準）。
+ * ファームウェアがコンテナ内テキストの自動スクロールを処理するため、
+ * 1チャンクを maxBytes UTF-8バイト以内に収める。
+ * SDKの文字数制限はUTF-8バイト基準（日本語3bytes/文字のため
+ * コードポイント数では正確に制御できない）。
+ * SCROLL_TOP/SCROLL_BOTTOM イベントはチャンク境界でのみ発火される。
+ *
+ * コードポイント単位で走査しサロゲートペア安全。
+ * 本文のインデントや空白は保持する（全体のtrimのみ）。
+ */
+const textEncoder = new TextEncoder()
+
+export function paginateText(text: string, maxBytes = 999): string[] {
+  const normalized = text?.replace(/\r\n/g, '\n').trim() ?? ''
+  if (!normalized) return ['（本文なし）']
+
+  const chars = Array.from(normalized)
   const pages: string[] = []
   let pos = 0
-  while (pos < text.length) {
-    let end = pos + charsPerPage
-    // 単語/行の途中で切らないよう、改行位置で調整
-    if (end < text.length) {
-      const lastNewline = text.lastIndexOf('\n', end)
-      if (lastNewline > pos) end = lastNewline + 1
+
+  while (pos < chars.length) {
+    let end = pos
+    let byteCount = 0
+    while (end < chars.length) {
+      const charBytes = textEncoder.encode(chars[end]).length
+      if (byteCount + charBytes > maxBytes) break
+      byteCount += charBytes
+      end++
     }
-    pages.push(text.slice(pos, end).trim())
+    if (end === pos) end = pos + 1 // 1文字がmaxBytesを超える場合は最低1文字進める
+
+    // 改行位置でチャンクを切る（改行なしの場合はバイト上限で強制カット）
+    if (end < chars.length) {
+      for (let i = end - 1; i > pos; i--) {
+        if (chars[i] === '\n') {
+          end = i + 1
+          break
+        }
+      }
+    }
+    pages.push(chars.slice(pos, end).join(''))
     pos = end
   }
+
   return pages.length > 0 ? pages : ['（本文なし）']
 }
 
@@ -430,8 +460,14 @@ export function createGlassesUI() {
     },
 
     /**
-     * G2に通知詳細を表示する（ページ送り対応）
-     * Up/Down: ページ送り
+     * G2に通知詳細を表示する（ファームウェアスクロール対応）
+     *
+     * fullTextをUTF-8バイト基準（デフォルト999bytes）でチャンク分割し、
+     * ファームウェアがコンテナ内テキストの自動スクロールを処理する。
+     * SCROLL_TOP/SCROLL_BOTTOM イベントはチャンク境界到達時のみアプリに通知される。
+     *
+     * 既にnotif-detailレイアウトの場合は textContainerUpgrade でテキストだけ更新する。
+     * レイアウト変更が必要な場合は createStartUp/rebuild で描画する。
      */
     async showNotificationDetail(
       conn: BridgeConnection,
@@ -475,12 +511,14 @@ export function createGlassesUI() {
           }),
         )
         if (h && b) {
-          log(`G2に通知詳細表示: "${detail.title}" page=${pageIndex + 1}/${pages.length}`)
+          log(`G2に通知詳細表示: "${detail.title}" chunk=${pageIndex + 1}/${pages.length} (${bodyText.length}chars, firmware scroll)`)
           return
         }
         log('G2 textContainerUpgrade に失敗 → ページ再描画へフォールバック')
       }
 
+      // paginateText() のデフォルト maxBytes=999 により、各チャンクは
+      // UTF-8で999バイト以内に収まっている（SDK上限 <1000 bytes）
       const headerContainer = new TextContainerProperty({
         xPosition: 8,
         yPosition: 4,
@@ -526,10 +564,10 @@ export function createGlassesUI() {
         targetLayout: 'notif-detail',
       })
       layoutByBridge.set(bridgeKeyOf(conn), 'notif-detail')
-      log(`G2に通知詳細表示: "${detail.title}" page=${pageIndex + 1}/${pages.length}`)
+      log(`G2に通知詳細表示: "${detail.title}" chunk=${pageIndex + 1}/${pages.length} (${bodyText.length}chars, firmware scroll)`)
     },
 
-    /** fullTextのページ数を返す */
+    /** fullTextのチャンク数を返す（各チャンクUTF-8で最大999bytes、ファームウェアスクロール） */
     getDetailPageCount(fullText: string): number {
       return paginateText(fullText).length
     },

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import { formatForG2Display } from './g2-format'
 import { appConfig, canUseGroqStt, createHubHeaders } from './config'
 import { getWebSpeechSupport, startWebSpeechCapture, type WebSpeechSession } from './stt/webspeech'
 import { createNotificationClient, type NotificationDetail, type NotificationItem } from './notifications'
-import { G2_EVENT, isDoubleTapEventType, isTapEventType, normalizeHubEvent } from './even-events'
+import { G2_EVENT, getNormalizedEventType, isDoubleTapEventType, isTapEventType, normalizeHubEvent } from './even-events'
 
 const appRoot = document.querySelector<HTMLDivElement>('#app')!
 const uiSearch = new URLSearchParams(globalThis.location?.search || '')
@@ -554,7 +554,7 @@ function startNotificationPolling() {
     // 描画中はスキップ（SDK呼び出し衝突防止）
     if (glassesUI.isRendering()) return
     try {
-      const items = await notifClient.list(10)
+      const items = await notifClient.list(20)
       hubReachable = true
       lastNotifRefreshAt = Date.now()
       const toKey = (list: NotificationItem[]) => list.map((i) => `${i.id}:${i.replyStatus ?? ''}`).join(',')
@@ -632,8 +632,8 @@ function updateNotifInfo() {
     infoEl.textContent = [
       `[詳細] ${d.title}`,
       `Source: ${d.source} | replyCapable: ${d.replyCapable}`,
-      `Page: ${notifState.detailPageIndex + 1}/${notifState.detailPages.length}`,
-      `操作: Up/Down=ページ, DblClick=戻る${replyHint}`,
+      `Chunk: ${notifState.detailPageIndex + 1}/${notifState.detailPages.length} (firmware scroll)`,
+      `操作: FW自動スクロール, 境界到達→チャンク切替, DblClick=戻る${replyHint}`,
       '',
       notifState.detailPages[notifState.detailPageIndex] ?? '',
     ].join('\n')
@@ -657,7 +657,7 @@ document.getElementById('notif-fetch-btn')!.addEventListener('click', async () =
   const statusEl = document.getElementById('notif-status')!
   statusEl.textContent = '取得中...'
   try {
-    const items = await notifClient.list(10)
+    const items = await notifClient.list(20)
     hubReachable = true
     lastNotifRefreshAt = Date.now()
     notifState.items = items
@@ -692,7 +692,7 @@ async function returnToListFromResult() {
   notifState.selectedIndex = 0
   if (connection) {
     try {
-      notifState.items = await notifClient.list(10)
+      notifState.items = await notifClient.list(20)
     } catch { /* fallback to cached */ }
     await glassesUI.showNotificationList(connection, notifState.items)
   }
@@ -705,6 +705,15 @@ function clearPendingNotifEvent() {
   if (pendingNotifEventFlushTimer) {
     clearTimeout(pendingNotifEventFlushTimer)
     pendingNotifEventFlushTimer = null
+  }
+}
+
+/** キュー中のイベントがスクロールの場合のみクリアする（tap/doubleTap等は保持） */
+function clearPendingScrollEvent() {
+  if (!pendingNotifEvent) return
+  const eventType = getNormalizedEventType(pendingNotifEvent)
+  if (eventType === G2_EVENT.SCROLL_TOP || eventType === G2_EVENT.SCROLL_BOTTOM) {
+    clearPendingNotifEvent()
   }
 }
 
@@ -858,12 +867,15 @@ async function handleNotifEvent(conn: BridgeConnection, event: EvenHubEvent) {
           try {
             const detail = await notifClient.detail(item.id)
             notifState.detailItem = detail
-            notifState.detailPages = []
             const pageCount = glassesUI.getDetailPageCount(detail.fullText)
-            for (let i = 0; i < pageCount; i++) notifState.detailPages.push('')
+            notifState.detailPages = Array.from({ length: pageCount }, (_, i) => String(i))
             notifState.detailPageIndex = 0
             notifState.screen = 'detail'
             await glassesUI.showNotificationDetail(connection!, detail, 0, pageCount, getContextPctForNotification(detail))
+            // 描画中（createStartUpフォールバックで数秒かかる）にキューされたスクロールイベントを破棄
+            // tap/doubleTap等の非スクロールイベントは保持する
+            clearPendingScrollEvent()
+            lastDetailScrollAt = Date.now()
             updateNotifInfo()
           } catch (err) {
             log(`通知詳細取得失敗: ${err instanceof Error ? err.message : String(err)}`)
@@ -872,7 +884,10 @@ async function handleNotifEvent(conn: BridgeConnection, event: EvenHubEvent) {
       } else if (notifState.screen === 'detail') {
         // 詳細画面: スクロールでページ送り＋画面遷移
         if (!notifState.detailItem) return
-        const pageCount = glassesUI.getDetailPageCount(notifState.detailItem.fullText)
+        // ghostリストコンテナからのイベントを無視（detail画面ではtextEventとsysEventのみ有効）
+        if (normalized.source === 'list') return
+        // detailPages は showNotificationDetail() で都度算出される（ここでは長さのみ参照）
+        const pageCount = notifState.detailPages.length
         if (isDoubleTapEventType(eventType)) {
           log('通知詳細: double tap → リストに戻る')
           notifState.screen = 'list'
@@ -893,6 +908,9 @@ async function handleNotifEvent(conn: BridgeConnection, event: EvenHubEvent) {
             await glassesUI.showNotificationDetail(
               connection!, notifState.detailItem, notifState.detailPageIndex, pageCount, getContextPctForNotification(notifState.detailItem),
             )
+            // 描画完了後にスクロールイベントのみクリア＋クールダウン更新（誤発火を防止）
+            clearPendingScrollEvent()
+            lastDetailScrollAt = Date.now()
           } else {
             log('通知詳細: 最初のページ → リストに戻る')
             notifState.screen = 'list'
@@ -911,6 +929,9 @@ async function handleNotifEvent(conn: BridgeConnection, event: EvenHubEvent) {
             await glassesUI.showNotificationDetail(
               connection!, notifState.detailItem, notifState.detailPageIndex, pageCount, getContextPctForNotification(notifState.detailItem),
             )
+            // 描画完了後にスクロールイベントのみクリア＋クールダウン更新（誤発火を防止）
+            clearPendingScrollEvent()
+            lastDetailScrollAt = Date.now()
           } else if (notifState.detailItem.replyCapable) {
             log('通知詳細: 最終ページ → アクションメニュー')
             notifState.screen = 'detail-actions'

--- a/test/paginate-text.test.ts
+++ b/test/paginate-text.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import { paginateText } from '../src/glasses-ui'
+
+/** UTF-8バイト数を返すヘルパー */
+const byteLen = (s: string) => new TextEncoder().encode(s).length
+
+describe('paginateText', () => {
+  it('空文字列 → ["（本文なし）"]', () => {
+    expect(paginateText('')).toEqual(['（本文なし）'])
+  })
+
+  it('null/undefined → ["（本文なし）"]', () => {
+    // @ts-expect-error -- 防御的テスト
+    expect(paginateText(null)).toEqual(['（本文なし）'])
+    // @ts-expect-error
+    expect(paginateText(undefined)).toEqual(['（本文なし）'])
+  })
+
+  it('999バイト以下のASCII → 1チャンク', () => {
+    const text = 'a'.repeat(999) // 999 bytes
+    const result = paginateText(text)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toBe(text)
+  })
+
+  it('1000バイトのASCII → 2チャンク', () => {
+    const text = 'a'.repeat(1000)
+    const result = paginateText(text)
+    expect(result).toHaveLength(2)
+    expect(byteLen(result[0])).toBe(999)
+    expect(byteLen(result[1])).toBe(1)
+  })
+
+  it('日本語テキストは3bytes/文字でチャンク分割される', () => {
+    // 'あ' = 3 bytes → 333文字 = 999 bytes (1チャンク), 334文字 = 1002 bytes (2チャンク) ※SDK上限999bytes
+    const text333 = 'あ'.repeat(333)
+    expect(paginateText(text333)).toHaveLength(1)
+    expect(byteLen(text333)).toBe(999)
+
+    const text334 = 'あ'.repeat(334)
+    expect(paginateText(text334)).toHaveLength(2)
+  })
+
+  it('各チャンクが999バイトを超えない', () => {
+    const text = 'あ'.repeat(1000) // 3000 bytes
+    const result = paginateText(text)
+    for (const chunk of result) {
+      expect(byteLen(chunk)).toBeLessThanOrEqual(999)
+    }
+    // 全チャンク結合で元テキストと一致
+    expect(result.join('')).toBe(text)
+  })
+
+  it('改行位置でチャンク分割される', () => {
+    // 989 bytes + \n + 20 bytes = 1010 bytes
+    const before = 'x'.repeat(989)
+    const after = 'y'.repeat(20)
+    const text = `${before}\n${after}`
+    const result = paginateText(text)
+    expect(result).toHaveLength(2)
+    expect(result[0]).toBe(before + '\n')
+    expect(result[1]).toBe(after)
+  })
+
+  it('カスタム maxBytes で分割できる', () => {
+    const text = 'a'.repeat(300)
+    const result = paginateText(text, 100)
+    expect(result).toHaveLength(3)
+  })
+
+  it('サロゲートペア（絵文字）を途中分割しない', () => {
+    // 🎉 = 4 UTF-8 bytes, 1 code point
+    const emoji = '🎉'
+    const text = emoji.repeat(250) // 250 * 4 = 1000 bytes → 2チャンク (999バイト上限)
+    const result = paginateText(text)
+    expect(result).toHaveLength(2)
+    // 各チャンクが不正な文字列を含まないことを確認
+    for (const chunk of result) {
+      expect(chunk).toBe(Array.from(chunk).join(''))
+      expect(byteLen(chunk)).toBeLessThanOrEqual(999)
+    }
+    expect(result.join('')).toBe(text)
+  })
+
+  it('チャンク内のインデントを保持する（先頭・末尾の全体trimは許容）', () => {
+    const text = 'line1\n    indented\nline3'
+    const result = paginateText(text)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toContain('    indented')
+  })
+
+  it('\\r\\n を \\n に正規化する', () => {
+    const text = 'line1\r\nline2\r\nline3'
+    const result = paginateText(text)
+    expect(result.join('')).not.toContain('\r')
+    expect(result.join('')).toContain('line1\nline2\nline3')
+  })
+
+  it('空白のみのテキスト → ["（本文なし）"]', () => {
+    expect(paginateText('   \n\n  ')).toEqual(['（本文なし）'])
+  })
+
+  it('混合テキスト（ASCII+日本語）が正しくバイト分割される', () => {
+    // 実際のユースケース: コマンド(ASCII) + 日本語説明
+    const ascii = 'gh pr create --title "test" --body "'
+    const japanese = '通知詳細画面のテキスト表示を変更' // 16文字 * 3 = 48 bytes
+    const text = ascii + japanese.repeat(20) // ascii(36bytes) + 960bytes = 996bytes → 1チャンク内
+    const result = paginateText(text)
+    expect(result).toHaveLength(1)
+    expect(byteLen(result[0])).toBeLessThanOrEqual(999)
+  })
+
+  it('816コードポイント/1424バイトの混合テキストがバイト基準で分割される', () => {
+    // 実際に問題が発生したケース: 816 cp / 1424 bytes
+    const mixed = 'ASCII部分 ' + '日本語テキスト'.repeat(50) // 多めの日本語
+    const result = paginateText(mixed)
+    expect(result.length).toBeGreaterThanOrEqual(2) // 1424 bytes > 999 maxBytes → 2チャンク以上
+    for (const chunk of result) {
+      expect(byteLen(chunk)).toBeLessThanOrEqual(999)
+    }
+    expect(result.join('')).toBe(mixed.replace(/\r\n/g, '\n').trim())
+  })
+})

--- a/test/voice-entry.test.mjs
+++ b/test/voice-entry.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
-import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdtemp, mkdir, readFile, rm, unlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { spawn } from 'node:child_process'
@@ -91,6 +91,21 @@ case "$cmd" in
       node -e 'console.log(JSON.stringify({ok:true, exists:false, sessionName:process.argv[1]}))' "$session"
     fi
     ;;
+  find-session)
+    workdir=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --workdir) workdir="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    base=$(basename "$workdir")
+    if [ -f "$STATE_DIR/continue-ok" ]; then
+      node -e 'console.log(JSON.stringify({ok:true, exists:true, sessionName:process.argv[1]}))' "g2-$base-stub"
+    else
+      node -e 'console.log(JSON.stringify({ok:true, exists:false}))'
+    fi
+    ;;
   launch-detached)
     workdir=""
     prompt=""
@@ -147,8 +162,12 @@ const chooseCandidate = (suffix) => {
 }
 if (textOutput) {
   const recent = readRecentSession()
-  if (prompt.includes('続けて') && recent?.workdir) {
-    process.stdout.write(JSON.stringify({ mode: 'continue_latest', workdir: recent.workdir, prompt: '続けてログ見て' }))
+  const spoken = prompt.split(/\\n/).find((l) => l.startsWith('spoken_request: '))?.slice('spoken_request: '.length) || ''
+  if (prompt.includes('続けて')) {
+    const candidates = ['alpha-tool', 'beta-tool']
+    const mentioned = candidates.find((c) => spoken.includes(c))
+    const target = mentioned ? chooseCandidate(mentioned) : (recent?.workdir || '')
+    process.stdout.write(JSON.stringify({ mode: 'continue_latest', workdir: target, prompt: '続けて' }))
   } else {
     const alpha = chooseCandidate('alpha-tool')
     process.stdout.write(JSON.stringify({ mode: 'start', workdir: alpha, prompt: 'alpha の修正して' }))
@@ -252,8 +271,77 @@ exec ${JSON.stringify(process.execPath)} ${JSON.stringify(claudeStub)} "$@"
     })
     expect(res.status).toBe(200)
     const data = await res.json()
-    expect(extractContent(data)).toContain('直前のClaude Codeセッションに続けて依頼しました')
+    expect(extractContent(data)).toContain('既存のClaude Codeセッションに続けて依頼しました')
     expect(extractContent(data)).toContain('beta-tool')
+  })
+
+  it('continues session for selector-chosen workdir even when lastSession differs', async () => {
+    // lastSession points to alpha-tool, but user asks to continue in beta-tool
+    await writeFile(
+      lastSessionFile,
+      JSON.stringify(
+        {
+          sessionName: 'g2-alpha-tool-stub',
+          workdir: path.join(repoRoot, 'alpha-tool'),
+          prompt: '前回の依頼',
+          updatedAt: new Date().toISOString(),
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    )
+    await writeFile(path.join(stateDir, 'continue-ok'), '1', 'utf8')
+
+    const res = await fetch(`${base}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${TEST_TOKEN}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'openclaw',
+        messages: [{ role: 'user', content: 'beta-toolで続けて' }],
+      }),
+    })
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(extractContent(data)).toContain('既存のClaude Codeセッションに続けて依頼しました')
+    expect(extractContent(data)).toContain('beta-tool')
+  })
+
+  it('starts new session when continue requested but no session exists for workdir', async () => {
+    await writeFile(
+      lastSessionFile,
+      JSON.stringify(
+        {
+          sessionName: 'g2-alpha-tool-stub',
+          workdir: path.join(repoRoot, 'alpha-tool'),
+          prompt: '前回の依頼',
+          updatedAt: new Date().toISOString(),
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    )
+    // Ensure continue-ok does not exist — find-session will return exists:false
+    try { await unlink(path.join(stateDir, 'continue-ok')) } catch {}
+
+    const res = await fetch(`${base}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${TEST_TOKEN}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'openclaw',
+        messages: [{ role: 'user', content: 'beta-toolで続けてお願い' }],
+      }),
+    })
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(extractContent(data)).toContain('新しいClaude Codeセッションを開始しました')
   })
 
   it('deduplicates identical requests sent within the dedup window', async () => {


### PR DESCRIPTION
## Summary
- Confirmed `createStartUpPageContainer` limit is **<1000 UTF-8 bytes** via hardware boundary testing (999 OK, 1000 NG). Adjusted `paginateText` maxBytes from 1000 to 999
- Raised `buildToolPreview()` slice limits from 200/300 to 2000 for Edit/Write/default tool previews (firmware scroll support)
- Added `X-CC-G2-Token` header to PermissionRequest hook for Hub auth, fixing notifications not reaching G2 after Hub restart
- Increased notification list from 10 to 20 items
- Updated tests for new 999-byte boundary

## Test plan
- [x] Hardware boundary test: 日本語333文字(999bytes) → OK, 334文字(1002bytes) → NG
- [x] Hardware boundary test: ASCII 999文字(999bytes) → OK, 1000文字(1000bytes) → NG
- [x] Write 2067文字 → 4チャンク分割でファームウェアスクロール閲覧OK
- [x] Edit長文diff → old/new が2000文字まで表示確認
- [x] PermissionRequest hook auth → Hub再起動後もG2に通知が届くこと確認
- [x] vitest 56テスト全パス