### PR TITLE
Fix G2 notification list display and bump vite to 7.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "typescript": "^5.9.3",
-    "vite": "^7.3.1",
+    "vite": "^7.3.2",
     "vitest": "^4.0.18"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
-        specifier: ^7.3.1
-        version: 7.3.1
+        specifier: ^7.3.2
+        version: 7.3.2
       vitest:
         specifier: ^4.0.18
         version: 4.0.18
@@ -466,8 +466,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -724,13 +724,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1)':
+  '@vitest/mocker@4.0.18(vite@7.3.2)':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1
+      vite: 7.3.2
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -874,7 +874,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  vite@7.3.1:
+  vite@7.3.2:
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.4)
@@ -888,7 +888,7 @@ snapshots:
   vitest@4.0.18:
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1)
+      '@vitest/mocker': 4.0.18(vite@7.3.2)
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -905,7 +905,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1
+      vite: 7.3.2
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - jiti

--- a/src/glasses-ui.ts
+++ b/src/glasses-ui.ts
@@ -152,33 +152,63 @@ function extractSnippet(summary: string, toolName: string): string {
 }
 
 /** 通知一覧のリスト項目を生成（G2リスト表示用） */
+/** UTF-8 バイト数で文字列を切り詰め。末尾に '…' を付ける。サロゲートペア安全。 */
+function truncateByBytes(text: string, maxBytes: number): string {
+  if (maxBytes <= 0) return ''
+  const fullBytes = textEncoder.encode(text).length
+  if (fullBytes <= maxBytes) return text
+  const ellipsis = '…'
+  const ellipsisBytes = textEncoder.encode(ellipsis).length
+  const budget = Math.max(0, maxBytes - ellipsisBytes)
+  const chars = Array.from(text)
+  let used = 0
+  let out = ''
+  for (const ch of chars) {
+    const chBytes = textEncoder.encode(ch).length
+    if (used + chBytes > budget) break
+    out += ch
+    used += chBytes
+  }
+  return out + ellipsis
+}
+
+function byteLen(text: string): number {
+  return textEncoder.encode(text).length
+}
+
 function formatListItemName(item: NotificationItem): string {
   const age = formatAge(item.createdAt)
   const s = item.replyStatus
   const mark = s === 'delivered' || s === 'replied' ? '○' : s === 'decided' ? '>' : '●'
-  // "○proj:Title cmd… (2m)" 形式で表示（最大34文字）
+  // バイト基準の切り詰め: createStartUp の総バイト上限 (known-limitations §5: 999 bytes) を
+  // 必ず下回るよう 1 アイテムあたり 45 bytes を上限とする。
+  // 日本語(3byte/char)主体でも 20件 × 45byte = 900 bytes、ヘッダ ~40 bytes、合計 ~940 bytes。
+  // 旧実装はコードポイント数で切っていたため日本語が混ざると 45char × 3byte = 135byte/item まで
+  // 膨らみ、20件で 2700 bytes に達してファームがページ全体を silently 破棄していた。
   const prefix = mark + getNotificationPrefix(item)
   const suffix = ` (${age})`
-  const maxLen = 34
-  const available = Math.max(5, maxLen - prefix.length - suffix.length)
+  const maxBytes = 45
+  const available = Math.max(6, maxBytes - byteLen(prefix) - byteLen(suffix))
   const toolName = item.title
   const snippet = extractSnippet(item.summary, toolName)
   let body: string
-  if (snippet && toolName.length + 1 + snippet.length <= available) {
-    // "Bash curl -s ..." のようにツール名+スニペットが全部入る
+  if (snippet) {
     const combined = `${toolName} ${snippet}`
-    body = combined.length > available ? combined.slice(0, available - 1) + '…' : combined
-  } else if (snippet) {
-    // ツール名を短縮してスニペットを優先
-    const snipSpace = available - toolName.length - 1
-    if (snipSpace >= 4) {
-      const snip = snippet.length > snipSpace ? snippet.slice(0, snipSpace - 1) + '…' : snippet
-      body = `${toolName} ${snip}`
+    if (byteLen(combined) <= available) {
+      body = combined
     } else {
-      body = toolName.length > available ? toolName.slice(0, available - 1) + '…' : toolName
+      // ツール名は最低限残し、残りをスニペットに割り当てる
+      const toolBytes = Math.min(byteLen(toolName), Math.max(6, Math.floor(available / 2)))
+      const toolPart = truncateByBytes(toolName, toolBytes)
+      const snipSpace = available - byteLen(toolPart) - 1
+      if (snipSpace >= 4) {
+        body = `${toolPart} ${truncateByBytes(snippet, snipSpace)}`
+      } else {
+        body = truncateByBytes(toolName, available)
+      }
     }
   } else {
-    body = toolName.length > available ? toolName.slice(0, available - 1) + '…' : toolName
+    body = truncateByBytes(toolName, available)
   }
   return `${prefix}${body}${suffix}`
 }
@@ -421,30 +451,22 @@ export function createGlassesUI() {
         return
       }
 
-      const headerText = `通知 ${items.length}件`
+      // 重要: 実機ファームは ListContainer + TextContainer 複数 の組み合わせを
+      // silently 破棄する（createStartUp の戻り値は 0/1 を返すが描画されない）。
+      // 検証 (2026-04-15):
+      //   - TextContainer 1個 + ListContainer 1個 → 表示 OK
+      //   - TextContainer 2個 + ListContainer 1個 → 矩形重なりを 8px ギャップで解消しても NG
+      // → ヘッダに時刻をインラインして TextContainer を1個に保つ。シミュレータは寛容で
+      //    どちらでも描画してしまうので、ここを変更したら必ず実機で確認する。
+      const headerText = `通知 ${items.length}件  ${formatCurrentDateTime()}`
       const titleContainer = new TextContainerProperty({
         xPosition: 8,
         yPosition: 8,
-        width: 388,
+        width: 560,
         height: 28,
         containerID: 1,
         containerName: 'notif-header',
         content: headerText,
-        isEventCapture: 0,
-      })
-
-      const timeContainer = new TextContainerProperty({
-        xPosition: 356,
-        yPosition: 2,
-        width: 212,
-        height: 36,
-        borderWidth: 1,
-        borderColor: 5,
-        borderRdaius: 4,
-        paddingLength: 4,
-        containerID: 3,
-        containerName: 'notif-time',
-        content: formatCurrentDateTime(),
         isEventCapture: 0,
       })
 
@@ -465,7 +487,7 @@ export function createGlassesUI() {
       })
 
       await renderStartupPage(conn, {
-        texts: [titleContainer, timeContainer],
+        texts: [titleContainer],
         lists: [listContainer],
         targetLayout: 'notif-list',
       })


### PR DESCRIPTION
## Summary

- **G2実機で通知一覧が表示されない問題を修正**: `ListContainer` と 複数の `TextContainer` を同じページに配置すると、ファームウェアがページ全体を silently 破棄する挙動を確認。SDK は成功コード (0/1) を返すがシミュレータのみで描画され、実機では何も表示されない。通知一覧画面では通知件数と時刻をヘッダ文字列にインライン結合し、`TextContainer` を1個に削減することで実機でも確実に描画されるように修正した。
- **通知一覧のリスト項目をバイト基準で切り詰めに変更**: `createStartUpPageContainer` の実機上限は UTF-8 で 999 バイトなので、コードポイント基準だと日本語を含む通知 20 件で上限を超えて非表示になるケースがあった。`formatListItemName` を UTF-8 バイト基準の切り詰め (`maxBytes=45`) に変更し、20 件 × 45 バイト + ヘッダで 999 バイト以下に収まるようにした。
- **Dependabot security advisories 対応で vite を 7.3.2 にバンプ**: 3件の vite 関連脆弱性 (2 high, 1 moderate) をパッチレベルのバージョンアップで解消。

## Test plan

- [x] G2 実機で通知一覧が表示されることを目視確認
- [x] 日本語・英語混在の通知 20 件で 999 バイト上限を超えずに表示されることを確認
- [x] シミュレータでの動作確認
- [x] `pnpm install` でロックファイル整合性を確認