### PR TITLE
Sync Codex approval and voice fixes

### DIFF
--- a/scripts/codex-stop-notify.sh
+++ b/scripts/codex-stop-notify.sh
@@ -41,11 +41,6 @@ if [ -z "$HOOK_INPUT" ]; then
   exit 0
 fi
 
-if ! command -v jq >/dev/null 2>&1; then
-  echo "[g2] codex-stop-notify: jq not found; skipping stop notification" >&2
-  exit 0
-fi
-
 CURRENT_STEP="parse_transport"
 HUB_PORT="${HUB_PORT:-8787}"
 HUB_URL="${HUB_URL:-http://127.0.0.1:${HUB_PORT}}"

--- a/server/notification-hub/index.mjs
+++ b/server/notification-hub/index.mjs
@@ -601,6 +601,8 @@ const HOOK_POLL_INTERVAL_MS = 2_000
 function buildToolPreview(toolName, toolInput) {
   if (toolName === 'Bash') {
     return toolInput?.command || ''
+  } else if (toolName === 'apply_patch') {
+    return buildApplyPatchPreview(toolInput)
   } else if (toolName === 'Edit') {
     const file = toolInput?.file_path || ''
     const old = (toolInput?.old_string || '').slice(0, 2000)
@@ -615,11 +617,57 @@ function buildToolPreview(toolName, toolInput) {
   }
 }
 
+function buildApplyPatchPreview(toolInput) {
+  const patch = getApplyPatchRawString(toolInput)
+  if (patch === null) return JSON.stringify(toolInput || {}).slice(0, 2000)
+
+  const fileLines = []
+  const seen = new Set()
+  for (const line of patch.split(/\r?\n/)) {
+    const match = line.match(/^\*\*\* (Add|Update|Delete) File: (.+)$/)
+    if (match) {
+      const label = match[1] === 'Add' ? 'add' : match[1] === 'Update' ? 'edit' : 'delete'
+      const key = `${label}:${match[2]}`
+      if (!seen.has(key)) {
+        seen.add(key)
+        fileLines.push(`- ${label} ${match[2]}`)
+      }
+    }
+  }
+
+  const patchLines = patch
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .slice(0, 80)
+    .map((line) => (line.length > 160 ? `${line.slice(0, 159)}…` : line))
+    .join('\n')
+
+  const summary = fileLines.length > 0
+    ? ['Files:', ...fileLines.slice(0, 12), ''].join('\n')
+    : ''
+  const truncated = patch.split(/\r?\n/).length > 80 ? '\n…' : ''
+  return `${summary}${patchLines}${truncated}`.slice(0, 4000)
+}
+
+function getApplyPatchRawString(toolInput) {
+  for (const key of ['command', 'input', 'patch']) {
+    const value = toolInput?.[key]
+    if (typeof value === 'string' && value.length > 0) return value
+  }
+  return null
+}
+
+function buildApprovalUiUrl() {
+  return `http://127.0.0.1:${port}/ui`
+}
+
 function spawnLocalNotification(toolName) {
   try {
+    const approvalUrl = buildApprovalUiUrl()
     const child = spawn('terminal-notifier', [
       '-title', 'Permission',
-      '-message', toolName,
+      '-message', `${toolName} approval pending`,
+      '-open', approvalUrl,
       '-sound', 'Glass',
     ], { timeout: 5000, stdio: 'ignore' })
     child.on('error', () => {}) // コマンド未導入時の ENOENT を無視

--- a/server/voice-entry/index.mjs
+++ b/server/voice-entry/index.mjs
@@ -51,6 +51,10 @@ const OUTPUT_INSTRUCTION = [
   'Prefer one short Japanese sentence, or two very short sentences at most.',
   'If a task would require long work, say briefly that it is too long for this UI and ask the user to narrow the request.',
 ].join(' ')
+const CODEX_TRIGGER_PATTERN =
+  /(?<![A-Za-z0-9_])(?:--codex|codex|code[\s　-]*x)(?![A-Za-z0-9_])|(?:コーデックス|コード[\s　-]*エックス|コード[\s　-]*x)/i
+const CODEX_TRIGGER_CLEANUP_PATTERN =
+  /(?<![A-Za-z0-9_])(?:--codex|codex|code[\s　-]*x)(?![A-Za-z0-9_])|(?:コーデックス|コード[\s　-]*エックス|コード[\s　-]*x)/gi
 const DEDUP_WINDOW_MS = 1000
 let _lastRequest = { content: '', time: 0, response: null }
 
@@ -192,7 +196,7 @@ function normalizeVoicePrompt(text) {
     .replace(/\b(z\s*repos?|zee\s*repos?)\b/gi, ' ')
     .replace(/\b(repos?|repo)\b/gi, ' ')
     .replace(/\b(cc\s*-?\s*g2|cg2|ccg\s*two|c c g 2|g2)\b/gi, ' ')
-    .replace(/\b(--codex|codex|code\s*x)\b/gi, ' ')
+    .replace(CODEX_TRIGGER_CLEANUP_PATTERN, ' ')
     .replace(/[&％%]/g, ' ')
     .replace(/\s{2,}/g, ' ')
     .trim()
@@ -200,7 +204,7 @@ function normalizeVoicePrompt(text) {
 }
 
 function detectAgentMode(text) {
-  return /(^|\s)(--codex|codex|code\s*x)(?=$|\s)/i.test(String(text || '')) ? 'codex' : 'claude'
+  return CODEX_TRIGGER_PATTERN.test(String(text || '')) ? 'codex' : 'claude'
 }
 
 function normalizeForMatch(text) {

--- a/test/hub-hook-endpoint.test.mjs
+++ b/test/hub-hook-endpoint.test.mjs
@@ -1,12 +1,13 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import http from 'node:http'
 import { spawn } from 'node:child_process'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
 const PROJECT_ROOT = path.resolve(import.meta.dirname, '..')
 const TEST_HUB_TOKEN = 'test-hub-token'
+let notifierArgsFile = ''
 
 function randomPort() {
   return 10000 + Math.floor(Math.random() * 50000)
@@ -40,14 +41,45 @@ async function waitForPendingApprovals(base, predicate, expectedCount, timeoutMs
   return data.items.filter(predicate)
 }
 
+async function waitForNotifierArgs(predicate, timeoutMs = 4000) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    let raw = ''
+    try {
+      raw = await readFile(notifierArgsFile, 'utf8')
+    } catch {
+      raw = ''
+    }
+    if (predicate(raw)) return raw
+    await new Promise((r) => setTimeout(r, 100))
+  }
+  try {
+    return await readFile(notifierArgsFile, 'utf8')
+  } catch {
+    return ''
+  }
+}
+
 describe('Notification Hub — Permission Request HTTP Hook Endpoint', () => {
   /** @type {import('node:child_process').ChildProcess} */
   let hubProc
   let hubBase = ''
   let tmpDataDir = ''
+  let tmpBinDir = ''
 
   beforeAll(async () => {
     tmpDataDir = await mkdtemp(path.join(tmpdir(), 'hub-hook-test-'))
+    tmpBinDir = await mkdtemp(path.join(tmpdir(), 'hub-hook-bin-'))
+    notifierArgsFile = path.join(tmpDataDir, 'terminal-notifier-args.log')
+    const notifierPath = path.join(tmpBinDir, 'terminal-notifier')
+    await writeFile(
+      notifierPath,
+      `#!/bin/sh
+printf '%s\\n' "$@" >> ${JSON.stringify(notifierArgsFile)}
+`,
+      'utf8',
+    )
+    await chmod(notifierPath, 0o755)
     const port = randomPort()
     hubBase = `http://127.0.0.1:${port}`
 
@@ -62,6 +94,7 @@ describe('Notification Hub — Permission Request HTTP Hook Endpoint', () => {
         HUB_PERMISSION_THREAD_DEDUP_MS: '200',
         NTFY_BASE_URL: '',
         HUB_REPLY_RELAY_CMD: '',
+        PATH: `${tmpBinDir}${path.delimiter}${process.env.PATH || ''}`,
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     })
@@ -88,6 +121,7 @@ describe('Notification Hub — Permission Request HTTP Hook Endpoint', () => {
       if (!hubProc.killed) hubProc.kill('SIGKILL')
     }
     await rm(tmpDataDir, { recursive: true, force: true }).catch(() => {})
+    await rm(tmpBinDir, { recursive: true, force: true }).catch(() => {})
   })
 
   it('POST /api/hooks/permission-request — creates approval and notification', async () => {
@@ -427,6 +461,86 @@ describe('Notification Hub — Permission Request HTTP Hook Endpoint', () => {
     if (pending) {
       await postJson(hubBase, `/api/approvals/${pending.id}/decide`, { decision: 'approve' })
     }
+    await hookPromise
+  })
+
+  it('POST /api/hooks/permission-request — apply_patch preview keeps real patch lines', async () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: src/app.ts',
+      '@@',
+      '-const x = 1',
+      '+const x = 2',
+      '*** End Patch',
+      '',
+    ].join('\n')
+    const hookBody = {
+      session_id: 'apply-patch-preview-test',
+      cwd: '/tmp/apply-patch-preview',
+      tool_name: 'apply_patch',
+      tool_input: { command: patch },
+    }
+
+    const hookPromise = postJson(hubBase, '/api/hooks/permission-request', hookBody)
+    await new Promise((r) => setTimeout(r, 500))
+
+    const { data: notifs } = await getJson(hubBase, '/api/notifications?limit=100')
+    const match = notifs.items.find((n) => n.title === 'apply_patch')
+    expect(match).toBeDefined()
+
+    const { data: detail } = await getJson(hubBase, `/api/notifications/${match.id}`)
+    expect(detail.item.fullText).toContain('Files:\n- edit src/app.ts')
+    expect(detail.item.fullText).toContain('*** Begin Patch\n*** Update File: src/app.ts')
+    expect(detail.item.fullText).toContain('-const x = 1\n+const x = 2')
+    expect(detail.item.fullText).not.toContain('\\n')
+
+    const notifierArgs = await waitForNotifierArgs((raw) =>
+      raw.includes('apply_patch approval pending') &&
+      raw.includes('http://127.0.0.1:') &&
+      raw.includes('/ui'),
+    )
+    expect(notifierArgs).toContain('-open')
+    expect(notifierArgs).not.toContain(TEST_HUB_TOKEN)
+
+    const [pending] = await waitForPendingApprovals(
+      hubBase,
+      (a) => a.toolName === 'apply_patch' && a.cwd === '/tmp/apply-patch-preview',
+      1,
+    )
+    expect(pending).toBeDefined()
+    await postJson(hubBase, `/api/approvals/${pending.id}/decide`, { decision: 'approve' })
+    await hookPromise
+  })
+
+  it('POST /api/hooks/permission-request — apply_patch preview skips empty command fallback', async () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: src/fallback.ts',
+      '@@',
+      '-const fallback = false',
+      '+const fallback = true',
+      '*** End Patch',
+    ].join('\n')
+    const hookBody = {
+      session_id: 'apply-patch-fallback-test',
+      cwd: '/tmp/apply-patch-fallback',
+      tool_name: 'apply_patch',
+      tool_input: { command: '', patch },
+    }
+
+    const hookPromise = postJson(hubBase, '/api/hooks/permission-request', hookBody)
+    const [pending] = await waitForPendingApprovals(
+      hubBase,
+      (a) => a.toolName === 'apply_patch' && a.cwd === '/tmp/apply-patch-fallback',
+      1,
+    )
+    expect(pending).toBeDefined()
+
+    const { data: detail } = await getJson(hubBase, `/api/notifications/${pending.notificationId}`)
+    expect(detail.item.fullText).toContain('Files:\n- edit src/fallback.ts')
+    expect(detail.item.fullText).toContain('-const fallback = false\n+const fallback = true')
+
+    await postJson(hubBase, `/api/approvals/${pending.id}/decide`, { decision: 'approve' })
     await hookPromise
   })
 

--- a/test/voice-entry.test.mjs
+++ b/test/voice-entry.test.mjs
@@ -270,6 +270,69 @@ exec ${JSON.stringify(process.execPath)} ${JSON.stringify(claudeStub)} "$@"
     expect(lastSession.agentMode).toBe('codex')
   })
 
+  it('does not treat media codecs requests as Codex trigger', async () => {
+    const res = await fetch(`${base}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${TEST_TOKEN}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'openclaw',
+        messages: [{ role: 'user', content: 'alpha tool で audio codecs の調査して' }],
+      }),
+    })
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(extractContent(data)).toContain('alpha-tool')
+
+    const lastSession = JSON.parse(await readFile(lastSessionFile, 'utf8'))
+    expect(lastSession.sessionName).toBe('g2-alpha-tool-stub')
+    expect(lastSession.agentMode).toBe('claude')
+  })
+
+  it('starts a Codex session when codex is adjacent to Japanese text', async () => {
+    const res = await fetch(`${base}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${TEST_TOKEN}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'openclaw',
+        messages: [{ role: 'user', content: 'alpha tool をcodexで修正して' }],
+      }),
+    })
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(extractContent(data)).toContain('新しいCodexセッションを開始しました')
+
+    const lastSession = JSON.parse(await readFile(lastSessionFile, 'utf8'))
+    expect(lastSession.sessionName).toBe('g2-alpha-tool-stub-codex')
+    expect(lastSession.agentMode).toBe('codex')
+  })
+
+  it('starts a Codex session when voice transcription uses Japanese codex spelling', async () => {
+    const res = await fetch(`${base}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${TEST_TOKEN}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'openclaw',
+        messages: [{ role: 'user', content: 'alpha tool ディレクトリでコーデックス。修正して' }],
+      }),
+    })
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(extractContent(data)).toContain('新しいCodexセッションを開始しました')
+
+    const lastSession = JSON.parse(await readFile(lastSessionFile, 'utf8'))
+    expect(lastSession.sessionName).toBe('g2-alpha-tool-stub-codex')
+    expect(lastSession.agentMode).toBe('codex')
+  })
+
   it('continues latest session when follow-up voice request refers to current work', async () => {
     await writeFile(
       lastSessionFile,


### PR DESCRIPTION
## What changed

Public sync of selected private changes only. This PR intentionally excludes README, docs, and workflow changes.

- Improve Codex `apply_patch` permission previews by rendering raw patch lines with a compact file summary.
- Make macOS permission notifications open the local approval UI when clicked.
- Improve Codex/Code X voice trigger detection and cleanup.
- Adjust Codex stop notification session label parsing.
- Add regression coverage for `apply_patch` preview formatting and voice trigger variants.

## Public audit

Checked the staged public diff for local absolute paths, `cc-g2-private` references, and secret-like fixed values. No hits were found in the selected 6-file diff.

## Validation

- `pnpm install`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run test/hub-hook-endpoint.test.mjs test/voice-entry.test.mjs`

## Not included

- `README.md` / `README.ja.md`: private install text was intentionally not synced.
- `docs/known-limitations.md`: docs are excluded by the private-to-public sync rule. The private update adds a 2026-04-15 note about ListContainer + multiple TextContainer layouts being silently dropped on device firmware.
- `.github/workflows/dependency-review.yml`: deletion was intentionally not synced.