### PR TITLE
Document Approval Dashboard bootstrap

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -328,7 +328,7 @@ cc-g2/
 - まず `cc-g2 doctor` で依存関係と Hub / Vite の状態を確認
 - 調子が悪いときは `cc-g2 !` でインフラを再起動
 - **PC 再起動後は `cc-g2 !` が必要**: Hub や Voice Entry のトークンが不整合になるため、PC 再起動後は必ず `cc-g2 !` で再起動してください
-- Approval Dashboard を開く場合は `TOKEN=$(cat tmp/notification-hub/hub-auth-token)` の後に `http://127.0.0.1:8787/ui?token=${TOKEN}` を使います
+- Approval Dashboard を開く場合は `cat tmp/notification-hub/hub-auth-token` で確認した値を `http://127.0.0.1:8787/ui?token=<token>` の `<token>` に入れて開きます。token 付き URL はブラウザ履歴に残る可能性があるため、秘密として扱ってください
 - **Voice entry が起動しない**: `cc-g2 status` で確認。`.env.local` に `CC_G2_VOICE_ENTRY_ENABLED=0` が設定されていないか確認し、`cc-g2 !` で再起動
 - **Even App から接続できない**: `cat tmp/voice-entry/voice-entry-token` でトークンを確認。Even App の Bearer トークンと一致しているか、Tailscale で iPhone → Mac に到達できるかも確認
 - **設定変更が反映されない**: `cc-g2 !` でインフラを再起動。tmux セッション外からは `cc-g2 stop && cc-g2`

--- a/README.md
+++ b/README.md
@@ -216,8 +216,10 @@ pnpm test:watch
 
 - Run `cc-g2 doctor` to check dependencies and service health
 - **After a PC restart, run `cc-g2 !`** to restart all services — Hub and Voice Entry tokens can get out of sync after a reboot
+- To open the Approval Dashboard, run `cat tmp/notification-hub/hub-auth-token` and replace `<token>` in `http://127.0.0.1:8787/ui?token=<token>`. Treat the token URL as sensitive because it may be saved in browser history.
 - If Voice Entry won't start: check `cc-g2 status` and make sure `CC_G2_VOICE_ENTRY_ENABLED=0` is not set in `.env.local`
 - If Even App can't connect: verify the Bearer token with `cat tmp/voice-entry/voice-entry-token` and check Tailscale connectivity
+- If config changes are not reflected, restart the infra with `cc-g2 !`. From outside the tmux session, use `cc-g2 stop && cc-g2`
 
 ## Links
 


### PR DESCRIPTION
## What changed

- Add the English README troubleshooting note for opening the Approval Dashboard with the Hub bootstrap token.
- Add the matching English note for restarting infra when config changes are not reflected.

This brings the English troubleshooting section in line with the existing Japanese README guidance.

## Validation

Docs-only change; no tests run.