### PR TITLE
Phase 0.5: Hub bind security baseline

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "voice-entry:dev": "node server/voice-entry/index.mjs",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run test/even-events.test.ts test/format-and-wav.test.ts test/paginate-text.test.ts test/hub-approval-api.test.mjs test/hub-hook-endpoint.test.mjs test/hub-codex-hook.test.mjs test/hub-location-api.test.mjs test/voice-entry.test.mjs",
+    "test": "vitest run test/even-events.test.ts test/format-and-wav.test.ts test/paginate-text.test.ts test/hub-approval-api.test.mjs test/hub-hook-endpoint.test.mjs test/hub-codex-hook.test.mjs test/hub-location-api.test.mjs test/hub-bind-mode.test.mjs test/voice-entry.test.mjs",
     "test:all": "vitest run",
     "test:watch": "vitest"
   },

--- a/scripts/cc-g2.sh
+++ b/scripts/cc-g2.sh
@@ -606,13 +606,14 @@ ensure_infra() {
     local hub_log="${G2_PROJECT_DIR}/tmp/notification-hub/hub.log"
     local allowed_origins="http://127.0.0.1:${VITE_PORT},http://localhost:${VITE_PORT}"
     local ts_ip
-    ts_ip=$(tailscale ip -4 2>/dev/null || true)
+    ts_ip=$(tailscale ip -4 2>/dev/null | head -n1 || true)
     if [ -n "$ts_ip" ]; then
       allowed_origins="${allowed_origins},http://${ts_ip}:${VITE_PORT}"
     fi
     mkdir -p "$(dirname "$hub_log")"
     nohup env -C "$G2_PROJECT_DIR" \
-      HUB_BIND=0.0.0.0 \
+      HUB_BIND_MODE="${HUB_BIND_MODE:-tailnet}" \
+      HUB_TAILSCALE_IP="$ts_ip" \
       HUB_PORT=$HUB_PORT \
       HUB_AUTH_TOKEN="$HUB_AUTH_TOKEN" \
       GROQ_API_KEY="$GROQ_API_KEY_RESOLVED" \
@@ -780,6 +781,27 @@ cmd_doctor() {
       warn "Hub auth token: mismatch (run cc-g2 !)"
       ok=false
     fi
+    local doctor_bind_mode="${HUB_BIND_MODE:-tailnet}"
+    local doctor_ts_ip
+    doctor_ts_ip=$(tailscale ip -4 2>/dev/null | head -n1 || true)
+    case "$doctor_bind_mode" in
+      tailnet)
+        if [ -n "$doctor_ts_ip" ]; then
+          info "Hub bind mode: tailnet (loopback + ${doctor_ts_ip})"
+        else
+          warn "Hub bind mode: tailnet (loopback only — Tailscale IP unavailable)"
+        fi
+        ;;
+      localhost)
+        info "Hub bind mode: localhost (phone access disabled)"
+        ;;
+      any)
+        warn "Hub bind mode: any (debug — exposed to all interfaces)"
+        ;;
+      *)
+        warn "Hub bind mode: ${doctor_bind_mode} (unknown — falls back to tailnet at runtime)"
+        ;;
+    esac
     warn "Hub is intended for Tailscale/local trusted networks only"
   else
     warn "Hub (port $HUB_PORT): stopped"

--- a/scripts/start-simulator.sh
+++ b/scripts/start-simulator.sh
@@ -40,6 +40,8 @@ resolve_groq_api_key() {
 
 GROQ_API_KEY_RESOLVED="$(resolve_groq_api_key)"
 
+ts_ip="$(tailscale ip -4 2>/dev/null | head -n1 || true)"
+
 mkdir -p "$CACHE_DIR" "$LOG_DIR"
 
 if [ -z "$HUB_AUTH_TOKEN" ] && [ -f "$HUB_AUTH_TOKEN_FILE" ]; then
@@ -50,9 +52,12 @@ fi
 if ! curl -s --max-time 1 "http://127.0.0.1:${HUB_PORT}/api/health" >/dev/null 2>&1; then
   echo "[start] Notification Hub on ${HUB_PORT}"
   ALLOWED_ORIGINS="http://127.0.0.1:${PORT},http://localhost:${PORT}"
+  if [ -n "$ts_ip" ]; then
+    ALLOWED_ORIGINS="${ALLOWED_ORIGINS},http://${ts_ip}:${PORT}"
+  fi
   (
     cd "$REPO_DIR"
-    nohup env HUB_BIND=0.0.0.0 HUB_PORT=$HUB_PORT HUB_AUTH_TOKEN="$HUB_AUTH_TOKEN" GROQ_API_KEY="$GROQ_API_KEY_RESOLVED" HUB_ALLOWED_ORIGINS="$ALLOWED_ORIGINS" \
+    nohup env HUB_BIND_MODE="${HUB_BIND_MODE:-tailnet}" HUB_TAILSCALE_IP="$ts_ip" HUB_PORT=$HUB_PORT HUB_AUTH_TOKEN="$HUB_AUTH_TOKEN" GROQ_API_KEY="$GROQ_API_KEY_RESOLVED" HUB_ALLOWED_ORIGINS="$ALLOWED_ORIGINS" \
       HUB_REPLY_RELAY_CMD='bash server/notification-hub/reply-relay.sh' \
       RELAY_ENABLE_TMUX=1 \
       RELAY_TMUX_AUTO_DETECT=1 \

--- a/server/notification-hub/index.mjs
+++ b/server/notification-hub/index.mjs
@@ -35,7 +35,7 @@ function resolveBindHosts() {
   if (bindMode === 'any') return ['0.0.0.0']
   const hosts = ['127.0.0.1']
   if (tailscaleIp) hosts.push(tailscaleIp)
-  else console.warn('[hub] Tailscale未稼働のため localhost only でlisten')
+  else console.warn('[hub] HUB_TAILSCALE_IP not set — listening on loopback only')
   return hosts
 }
 
@@ -1414,6 +1414,11 @@ await bootstrap()
 const bindHosts = resolveBindHosts()
 const servers = bindHosts.map((bindHost) => {
   const s = createServer(handler)
+  s.on('error', (err) => {
+    log(`[hub] listen failed on ${bindHost}: ${err.code} ${err.message}`)
+    process.exitCode = 1
+    shutdown('listen-error')
+  })
   s.listen(port, bindHost, () => {
     log(`notification-hub listening on http://${bindHost}:${port}`)
   })
@@ -1427,6 +1432,7 @@ function shutdown(signal) {
   log(`notification-hub shutting down (${signal})`)
   for (const s of servers) {
     try { s.close() } catch {}
+    try { s.closeAllConnections() } catch {}
   }
 }
 process.on('SIGINT', () => shutdown('SIGINT'))

--- a/server/notification-hub/index.mjs
+++ b/server/notification-hub/index.mjs
@@ -15,7 +15,30 @@ import {
 } from './notification-utils.mjs'
 import { transcribeAudioWithGroq } from './stt.mjs'
 
-const host = process.env.HUB_BIND || '0.0.0.0'
+const legacyHubBind = process.env.HUB_BIND
+const bindModeRaw = process.env.HUB_BIND_MODE
+let bindMode = bindModeRaw || 'tailnet'
+if (!['tailnet', 'localhost', 'any'].includes(bindMode)) {
+  console.warn(`[hub] unknown HUB_BIND_MODE="${bindMode}" — falling back to "tailnet"`)
+  bindMode = 'tailnet'
+}
+const tailscaleIp = String(process.env.HUB_TAILSCALE_IP || '').trim()
+
+// Internal hook scripts hard-code http://127.0.0.1:8787, so 'tailnet' must keep
+// loopback reachable while phones reach us via the Tailscale IP. See design §7.1.
+function resolveBindHosts() {
+  if (!bindModeRaw && legacyHubBind) {
+    console.warn('[hub] HUB_BIND is deprecated — set HUB_BIND_MODE (tailnet|localhost|any) instead')
+    return [legacyHubBind]
+  }
+  if (bindMode === 'localhost') return ['127.0.0.1']
+  if (bindMode === 'any') return ['0.0.0.0']
+  const hosts = ['127.0.0.1']
+  if (tailscaleIp) hosts.push(tailscaleIp)
+  else console.warn('[hub] Tailscale未稼働のため localhost only でlisten')
+  return hosts
+}
+
 const port = Number(process.env.HUB_PORT || '8787')
 const dataDir = path.resolve(process.env.HUB_DATA_DIR || 'tmp/notification-hub')
 const hubAuthToken = String(process.env.HUB_AUTH_TOKEN || '').trim()
@@ -803,7 +826,7 @@ async function handlePermissionRequestHook(req, res) {
   sendJson(res, 200, {})
 }
 
-const server = createServer(async (req, res) => {
+const handler = async (req, res) => {
   const method = req.method || 'GET'
   const url = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`)
   const pathname = url.pathname
@@ -1384,9 +1407,27 @@ const server = createServer(async (req, res) => {
     }
     throw err
   }
-})
+}
 
 await bootstrap()
-server.listen(port, host, () => {
-  log(`notification-hub listening on http://${host}:${port}`)
+
+const bindHosts = resolveBindHosts()
+const servers = bindHosts.map((bindHost) => {
+  const s = createServer(handler)
+  s.listen(port, bindHost, () => {
+    log(`notification-hub listening on http://${bindHost}:${port}`)
+  })
+  return s
 })
+
+let shuttingDown = false
+function shutdown(signal) {
+  if (shuttingDown) return
+  shuttingDown = true
+  log(`notification-hub shutting down (${signal})`)
+  for (const s of servers) {
+    try { s.close() } catch {}
+  }
+}
+process.on('SIGINT', () => shutdown('SIGINT'))
+process.on('SIGTERM', () => shutdown('SIGTERM'))

--- a/test/hub-bind-mode.test.mjs
+++ b/test/hub-bind-mode.test.mjs
@@ -1,0 +1,187 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import http from 'node:http'
+import { spawn } from 'node:child_process'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+const PROJECT_ROOT = path.resolve(import.meta.dirname, '..')
+const TEST_HUB_TOKEN = 'test-hub-bind-token'
+
+// Use ::1 (IPv6 loopback) as a stand-in "Tailnet IP" — 127.0.0.2 is not aliased
+// on stock macOS, but ::1 is always available alongside 127.0.0.1.
+const FAKE_TAILNET_IP = '::1'
+
+let portCounter = 18787
+
+function nextPort() {
+  return portCounter++
+}
+
+function getStatus(host, port) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(
+      {
+        host,
+        port,
+        path: '/api/health',
+        headers: { 'X-CC-G2-Token': TEST_HUB_TOKEN },
+        timeout: 1500,
+      },
+      (res) => {
+        res.resume()
+        resolve(res.statusCode)
+      },
+    )
+    req.on('error', reject)
+    req.on('timeout', () => {
+      req.destroy(new Error('timeout'))
+    })
+  })
+}
+
+async function waitFor(host, port, timeoutMs = 6000) {
+  const deadline = Date.now() + timeoutMs
+  let lastErr
+  while (Date.now() < deadline) {
+    try {
+      const status = await getStatus(host, port)
+      if (status === 200) return true
+    } catch (err) {
+      lastErr = err
+    }
+    await new Promise((r) => setTimeout(r, 100))
+  }
+  throw lastErr || new Error(`Hub on ${host}:${port} did not become ready`)
+}
+
+async function spawnHub({ port, mode, tailIp, legacyBind }) {
+  const dataDir = await mkdtemp(path.join(tmpdir(), 'hub-bind-test-'))
+  const env = {
+    ...process.env,
+    HUB_PORT: String(port),
+    HUB_DATA_DIR: dataDir,
+    HUB_AUTH_TOKEN: TEST_HUB_TOKEN,
+    NTFY_BASE_URL: '',
+    HUB_REPLY_RELAY_CMD: '',
+  }
+  delete env.HUB_BIND
+  delete env.HUB_BIND_MODE
+  delete env.HUB_TAILSCALE_IP
+  if (mode !== undefined) env.HUB_BIND_MODE = mode
+  if (tailIp !== undefined) env.HUB_TAILSCALE_IP = tailIp
+  if (legacyBind !== undefined) env.HUB_BIND = legacyBind
+
+  const proc = spawn('node', ['server/notification-hub/index.mjs'], {
+    cwd: PROJECT_ROOT,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  let stderrBuf = ''
+  proc.stderr.on('data', (chunk) => {
+    stderrBuf += chunk.toString('utf8')
+  })
+  let stdoutBuf = ''
+  proc.stdout.on('data', (chunk) => {
+    stdoutBuf += chunk.toString('utf8')
+  })
+  return {
+    proc,
+    dataDir,
+    getStderr: () => stderrBuf,
+    getStdout: () => stdoutBuf,
+  }
+}
+
+async function teardown(handle) {
+  if (!handle) return
+  const { proc, dataDir } = handle
+  if (proc && !proc.killed) {
+    proc.kill('SIGTERM')
+    await new Promise((resolve) => {
+      const t = setTimeout(() => {
+        if (!proc.killed) proc.kill('SIGKILL')
+        resolve()
+      }, 1500)
+      proc.on('exit', () => {
+        clearTimeout(t)
+        resolve()
+      })
+    })
+  }
+  if (dataDir) await rm(dataDir, { recursive: true, force: true }).catch(() => {})
+}
+
+describe('Notification Hub — bind mode selector', () => {
+  /** @type {Awaited<ReturnType<typeof spawnHub>> | null} */
+  let handle = null
+
+  afterEach(async () => {
+    await teardown(handle)
+    handle = null
+  })
+
+  it('tailnet mode: listens on loopback AND HUB_TAILSCALE_IP', async () => {
+    const port = nextPort()
+    handle = await spawnHub({ port, mode: 'tailnet', tailIp: FAKE_TAILNET_IP })
+
+    await waitFor('127.0.0.1', port)
+    const loopbackStatus = await getStatus('127.0.0.1', port)
+    expect(loopbackStatus).toBe(200)
+
+    const tailStatus = await getStatus(FAKE_TAILNET_IP, port)
+    expect(tailStatus).toBe(200)
+  }, 15000)
+
+  it('tailnet mode without HUB_TAILSCALE_IP: loopback only (warning emitted)', async () => {
+    const port = nextPort()
+    handle = await spawnHub({ port, mode: 'tailnet' })
+
+    await waitFor('127.0.0.1', port)
+    const loopbackStatus = await getStatus('127.0.0.1', port)
+    expect(loopbackStatus).toBe(200)
+
+    // best-effort: warning should mention Tailscale unavailability
+    expect(handle.getStderr()).toMatch(/Tailscale/i)
+  }, 15000)
+
+  it('localhost mode: binds only to 127.0.0.1 (non-loopback rejected)', async () => {
+    const port = nextPort()
+    handle = await spawnHub({ port, mode: 'localhost' })
+
+    await waitFor('127.0.0.1', port)
+    const loopbackStatus = await getStatus('127.0.0.1', port)
+    expect(loopbackStatus).toBe(200)
+
+    let connectError
+    try {
+      await getStatus(FAKE_TAILNET_IP, port)
+    } catch (err) {
+      connectError = err
+    }
+    expect(connectError).toBeDefined()
+    expect(String(connectError && connectError.code)).toMatch(/ECONNREFUSED|ENOTFOUND|EADDRNOTAVAIL/)
+  }, 15000)
+
+  it('any mode: binds 0.0.0.0 (loopback reachable)', async () => {
+    const port = nextPort()
+    handle = await spawnHub({ port, mode: 'any' })
+
+    await waitFor('127.0.0.1', port)
+    const loopbackStatus = await getStatus('127.0.0.1', port)
+    expect(loopbackStatus).toBe(200)
+
+    expect(handle.getStdout()).toMatch(/listening on http:\/\/0\.0\.0\.0:/)
+  }, 15000)
+
+  it('legacy HUB_BIND env var still works (mapped to any-style single host)', async () => {
+    const port = nextPort()
+    handle = await spawnHub({ port, legacyBind: '127.0.0.1' })
+
+    await waitFor('127.0.0.1', port)
+    const loopbackStatus = await getStatus('127.0.0.1', port)
+    expect(loopbackStatus).toBe(200)
+
+    expect(handle.getStderr()).toMatch(/HUB_BIND/i)
+  }, 15000)
+})


### PR DESCRIPTION
Hub bind security baseline: HUB_BIND_MODE=tailnet|localhost|any, dual-listen on loopback+Tailnet IP, doctor mode display, error listener + closeAllConnections graceful shutdown, start-simulator.sh migrated. 83 tests green (78 baseline + 5 new). Codex review clean. Refs design doc §7.1.