### PR TITLE
Restore public README overwritten by #17

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,21 +1,21 @@
-# cc-g2 — Claude Code を声で操作するスマートグラス連携
+# cc-g2 — Claude Code / Codex CLI を G2 から操作するスマートグラス連携
 
 [English README](./README.md)
 
-Even G2 と Claude Code をつなぎ、承認・拒否・音声コメント・完了通知確認をグラスから行うためのハンズフリー companion layer です。PC の前にいなくても、iPhone 経由で G2 から Claude Code の permission request に応答できます。
+Even G2 と Claude Code / Codex CLI をつなぎ、承認・拒否・音声コメント・完了通知確認をグラスから行うためのハンズフリー companion layer です。PC の前にいなくても、iPhone 経由で G2 から agent の permission request に応答できます。
 
 ![cc-g2 simulator demo](./docs/screenshots/cc-g2-simulator.gif)
 
-Even G2 で通知を開き、音声で返答し、その内容を Claude Code に返す流れをシミュレーターで確認できます。
+Even G2 で通知を開き、音声で返答し、その内容を Claude Code や Codex CLI に返す流れをシミュレーターで確認できます。
 
 ## できること
 
-- **承認 / 拒否**: Claude Code の tool permission request に G2 から応答
+- **承認 / 拒否**: Claude Code / Codex CLI の tool permission request に G2 から応答
 - **AskUserQuestion への回答**: Claude Code の質問に、G2 の選択肢リストから回答
 - **音声コメント**: 拒否時に音声で指示を返す
-- **完了通知の確認**: Claude Code の完了通知を G2 で確認
+- **完了通知の確認**: Claude Code / Codex CLI の完了通知を G2 で確認
 - **通知一覧 / 詳細表示**: G2 で最近の通知を確認
-- **音声でセッション起動**: G2 に話しかけて Claude Code セッションを起動（Even App カスタム AI 連携）
+- **音声でセッション起動**: G2 に話しかけて Claude Code / Codex CLI セッションを起動（Even App カスタム AI 連携）
 
 ## 現在の制限
 
@@ -29,7 +29,7 @@ Even G2 で通知を開き、音声で返答し、その内容を Claude Code �
 ```text
 ┌──────────────┐   Tailscale    ┌──────────────┐   BLE    ┌─────────┐
 │ PC (Mac)     │ ◄───────────► │ iPhone       │ ◄──────► │ Even G2 │
-│ Claude Code  │               │ Even App     │          │         │
+│ Claude/Codex │               │ Even App     │          │         │
 │ Hub (:8787)  │               │ Vite (:5173) │          │         │
 │ Voice(:8797) │               │              │          │         │
 └──────────────┘               └──────────────┘          └─────────┘
@@ -38,15 +38,15 @@ Even G2 で通知を開き、音声で返答し、その内容を Claude Code �
 - **Notification Hub** (`:8787`): 通知と承認の中央管理
 - **Vite** (`:5173`): G2 向け Web UI
 - **Voice Entry** (`:8797`): 音声セッション起動（オプション）
-- **Claude Code HTTP hook**: PermissionRequest を Hub に送信
+- **Claude Code HTTP hook / Codex command hook**: PermissionRequest を Hub に送信
 
-Hub は明示的な permission prompt を中継して応答するためのもので、Claude Code のユーザー設定や組織ポリシーを上書きして独自に広く許可するものではありません。
+Hub は明示的な permission prompt を中継して応答するためのもので、Claude Code / Codex CLI のユーザー設定や組織ポリシーを上書きして独自に広く許可するものではありません。
 
 ## 推奨構成
 
 `cc-g2` は、**tmux + Tailscale + iPhone + Even G2** の構成で使うと安定しやすいです。
 
-- **tmux**: Claude Code セッションを維持し、reply relay の前提になります
+- **tmux**: Claude Code / Codex CLI セッションを維持し、reply relay の前提になります
 - **Tailscale**: iPhone からローカル Hub へ安全にアクセスしやすくなります。同じ WiFi ならローカル IP でも接続可能ですが、外出先や別ネットワークからの接続には Tailscale が便利です
 - **Moshi などの補助通知**: 必須ではありませんが、離席中の通知確認を補助しやすくなります
 - **通知運用**: G2 で承認待ちや完了を確認できます
@@ -69,20 +69,17 @@ Hub は明示的な permission prompt を中継して応答するためのもの
 
 ### 1. インストール
 
-Private GitHub Packages から入れる場合:
+GitHub から直接入れる場合:
 
 ```bash
-pnpm config set @wmoto-ai:registry https://npm.pkg.github.com
-pnpm add -g @wmoto-ai/cc-g2
+pnpm add -g github:wmoto-ai/cc-g2
 ```
-
-Private GitHub Packages から入れるには、package read 権限を持つ GitHub token を npm config に設定しておく必要があります。
 
 git clone から入れる場合:
 
 ```bash
-git clone https://github.com/wmoto-ai/cc-g2-private.git
-cd cc-g2-private
+git clone https://github.com/wmoto-ai/cc-g2.git
+cd cc-g2
 pnpm install
 pnpm link --global
 ```
@@ -118,6 +115,16 @@ cc-g2
 3. tmux セッション作成
 4. QR コード表示
 5. Claude Code 起動
+
+Codex CLI で起動する場合:
+
+```bash
+cc-g2 --codex
+# または
+cc-g2 codex
+```
+
+この場合は Codex CLI の hook を注入し、Codex CLI を G2 hook 付きで起動します。
 
 ### 4. 最初の確認
 
@@ -190,7 +197,7 @@ StatusLine 連携は既定で有効です。`~/.claude/settings.json` に `statu
 4. STT 結果を確認して **送信 / 再録 / キャンセル** を選ぶ
 5. **スワイプで録音キャンセル** も可能
 
-コメントは Claude Code に **拒否 + 指示テキスト** として返ります。
+コメントは Claude Code / Codex CLI に **拒否 + 指示テキスト** として返ります。
 
 ### AskUserQuestion への回答
 
@@ -207,21 +214,21 @@ Claude Code が `AskUserQuestion` を出した場合、cc-g2 は通常の通知�
 ## 承認の流れ
 
 ```text
-Claude Code ─ POST /api/hooks/permission-request ─► Hub
+Claude Code / Codex CLI ─ PermissionRequest hook ─► Hub
      │                                              │
      │                                   通知 / 承認待ちを作成
      │                                              │
      │◄──────────── 承認 / 拒否 / コメント ─────── G2
 ```
 
-- **承認**: Claude Code がそのまま実行
-- **拒否**: Claude Code が中止
+- **承認**: Claude Code / Codex CLI がそのまま実行
+- **拒否**: Claude Code / Codex CLI が中止
 - **コメント**: 拒否 + 指示テキストとして返却
-- **Hub 未起動**: Claude Code は通常の PC ダイアログへフォールバック
+- **Hub 未起動**: agent 側の通常 UI / エラー処理へフォールバック
 
 ## 音声セッション起動 (Voice Entry)
 
-G2 の「Hey Even」で Claude Code セッションを音声起動できます。Even App のカスタム AI 機能を使い、発話内容からリポジトリを自動判定してセッションを開始します。
+G2 の「Hey Even」で Claude Code / Codex CLI セッションを音声起動できます。Even App のカスタム AI 機能を使い、発話内容からリポジトリを自動判定してセッションを開始します。発話に `codex` を含めると Codex CLI セッションとして起動します。
 
 ### 有効化
 
@@ -321,7 +328,7 @@ cc-g2/
 - まず `cc-g2 doctor` で依存関係と Hub / Vite の状態を確認
 - 調子が悪いときは `cc-g2 !` でインフラを再起動
 - **PC 再起動後は `cc-g2 !` が必要**: Hub や Voice Entry のトークンが不整合になるため、PC 再起動後は必ず `cc-g2 !` で再起動してください
-- Approval Dashboard を開く場合は `TOKEN=$(cat tmp/notification-hub/hub-auth-token)` の後に `http://127.0.0.1:8787/ui?token=${TOKEN}` を使います
+- Approval Dashboard を開く場合は `cat tmp/notification-hub/hub-auth-token` で確認した値を `http://127.0.0.1:8787/ui?token=<token>` の `<token>` に入れて開きます。token 付き URL はブラウザ履歴に残る可能性があるため、秘密として扱ってください
 - **Voice entry が起動しない**: `cc-g2 status` で確認。`.env.local` に `CC_G2_VOICE_ENTRY_ENABLED=0` が設定されていないか確認し、`cc-g2 !` で再起動
 - **Even App から接続できない**: `cat tmp/voice-entry/voice-entry-token` でトークンを確認。Even App の Bearer トークンと一致しているか、Tailscale で iPhone → Mac に到達できるかも確認
 - **設定変更が反映されない**: `cc-g2 !` でインフラを再起動。tmux セッション外からは `cc-g2 stop && cc-g2`

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-# cc-g2 — Smart glasses companion for Claude Code
+# cc-g2 — Smart glasses companion for Claude Code / Codex CLI
 
 [日本語 README](./README.ja.md)
 
-`cc-g2` connects Even G2 smart glasses to Claude Code so you can review permission prompts, send voice comments, and check completion notifications without staying at your desk.
+`cc-g2` connects Even G2 smart glasses to Claude Code / Codex CLI so you can review permission prompts, send voice comments, and check completion notifications without staying at your desk.
 
 ![cc-g2 simulator demo](./docs/screenshots/cc-g2-simulator.gif)
 
-Even G2 can open notifications, record a voice reply, and send that response back to Claude Code through the local Hub.
+Even G2 can open notifications, record a voice reply, and send that response back to Claude Code or Codex CLI through the local Hub.
 
 ## What works today
 
-- Approve / deny Claude Code permission requests from G2
+- Approve / deny Claude Code / Codex CLI permission requests from G2
 - Answer Claude Code `AskUserQuestion` prompts from G2 option lists
-- Send voice comments back to Claude Code
-- Check completion notifications on G2
+- Send voice comments back to Claude Code / Codex CLI
+- Check Claude Code / Codex CLI completion notifications on G2
 - Browse recent notifications and details on the glasses
-- Launch Claude Code sessions by voice via Even App custom AI
+- Launch Claude Code / Codex CLI sessions by voice via Even App custom AI
 
 ## Current limitations
 
@@ -27,21 +27,21 @@ Even G2 can open notifications, record a voice reply, and send that response bac
 ## Architecture
 
 ```text
-PC (Claude Code + Hub + Voice Entry) <-> iPhone (Even App + Vite UI) <-> Even G2
+PC (Claude Code / Codex CLI + Hub + Voice Entry) <-> iPhone (Even App + Vite UI) <-> Even G2
 ```
 
 - **Notification Hub** (`:8787`) handles notifications and approval flow
 - **Vite UI** (`:5173`) provides the G2 companion web UI
 - **Voice Entry** (`:8797`) launches sessions by voice (optional)
-- **Claude Code HTTP hook** sends permission requests to the Hub
+- **Claude Code HTTP hook / Codex command hook** sends permission requests to the Hub
 
-The Hub is intended to mirror and answer explicit permission prompts. It should not broaden Claude Code permissions or override user / org policy outside the normal `approve` / `deny` flow.
+The Hub is intended to mirror and answer explicit permission prompts. It should not broaden Claude Code / Codex CLI permissions or override user / org policy outside the normal `approve` / `deny` flow.
 
 ## Recommended setup
 
 `cc-g2` works best with a setup based on **tmux + Tailscale + iPhone + Even G2**.
 
-- **tmux** keeps the Claude Code session alive and supports the reply relay flow
+- **tmux** keeps the Claude Code / Codex CLI session alive and supports the reply relay flow
 - **Tailscale** makes it easier for the iPhone to reach the local Hub safely. You can also use a local IP on the same WiFi, but Tailscale is convenient for remote or cross-network access
 - **Moshi or similar helper notifications** are optional, but useful when you are away from your desk
 - **G2 notifications** are useful for checking pending approvals and completions
@@ -64,20 +64,17 @@ Reference: <https://getmoshi.app/articles/mac-remote-endless-agent-setup>
 
 ### 1. Install
 
-Private GitHub Packages install:
+Install directly from GitHub:
 
 ```bash
-pnpm config set @wmoto-ai:registry https://npm.pkg.github.com
-pnpm add -g @wmoto-ai/cc-g2
+pnpm add -g github:wmoto-ai/cc-g2
 ```
-
-Private GitHub Packages access requires a GitHub token with package read permission in your npm config.
 
 Source checkout install:
 
 ```bash
-git clone https://github.com/wmoto-ai/cc-g2-private.git
-cd cc-g2-private
+git clone https://github.com/wmoto-ai/cc-g2.git
+cd cc-g2
 pnpm install
 pnpm link --global
 ```
@@ -108,6 +105,16 @@ cc-g2
 ```
 
 This starts the Hub and Vite UI, injects Claude Code hooks, prepares a tmux session, shows a QR code, and launches Claude Code.
+
+To start Codex CLI instead:
+
+```bash
+cc-g2 --codex
+# or
+cc-g2 codex
+```
+
+This injects Codex CLI hooks and launches Codex CLI with G2 approval/completion notifications.
 
 ## Commands
 
@@ -141,7 +148,7 @@ This starts the Hub and Vite UI, injects Claude Code hooks, prepares a tmux sess
 4. Choose **Send / Retry / Cancel** after STT finishes
 5. **Swipe cancels recording** while recording is active
 
-Voice comments are returned to Claude Code as **deny + instruction text**.
+Voice comments are returned to Claude Code / Codex CLI as **deny + instruction text**.
 
 ### AskUserQuestion flow
 
@@ -157,7 +164,7 @@ Selected answers are sent back through the Hub as an answer payload for the matc
 
 ## Voice Entry
 
-Launch Claude Code sessions by speaking to G2 via Even App's custom AI agent.
+Launch Claude Code / Codex CLI sessions by speaking to G2 via Even App's custom AI agent. Include `codex` in the spoken request to start a Codex CLI session.
 
 ### Setup
 
@@ -209,8 +216,10 @@ pnpm test:watch
 
 - Run `cc-g2 doctor` to check dependencies and service health
 - **After a PC restart, run `cc-g2 !`** to restart all services — Hub and Voice Entry tokens can get out of sync after a reboot
+- To open the Approval Dashboard, run `cat tmp/notification-hub/hub-auth-token` and replace `<token>` in `http://127.0.0.1:8787/ui?token=<token>`. Treat the token URL as sensitive because it may be saved in browser history.
 - If Voice Entry won't start: check `cc-g2 status` and make sure `CC_G2_VOICE_ENTRY_ENABLED=0` is not set in `.env.local`
 - If Even App can't connect: verify the Bearer token with `cat tmp/voice-entry/voice-entry-token` and check Tailscale connectivity
+- If config changes are not reflected, restart the infra with `cc-g2 !`. From outside the tmux session, use `cc-g2 stop && cc-g2`
 
 ## Links
 


### PR DESCRIPTION
PR #17 accidentally overwrote the public README with the private repo's version (cc-g2-private clone URL + Private GitHub Packages install steps). This restores the correct public README (cc-g2 URL, no private package steps). Code changes from #17 are unaffected.