### PR TITLE
Mirror all client logs to Hub for diagnosis

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -18,16 +18,18 @@ export function log(message: string): void {
     }
   }
 
-  // 通知フロー診断のため、通知系ログだけHubへミラーする（非同期・失敗は無視）
-  if (!message.startsWith('通知')) return
+  // 画面遷移・G2描画・イベントを含む全ログをHubへミラーする（非同期・失敗は無視）。
+  // 以前は「通知」始まりのログだけ送っていたため、startup描画失敗(code=1)や
+  // 待機/一覧の画面遷移・[event]系がPC側に届かず、原因追跡が不能だった。
   const baseUrl = appConfig.notificationHubUrl
   if (!baseUrl) return
+  const level = /失敗|エラー|error|code=[1-3]/.test(message) ? 'error' : 'info'
   void fetch(`${baseUrl}/api/client-events`, {
     method: 'POST',
     headers: createHubHeaders({ 'Content-Type': 'application/json' }),
     body: JSON.stringify({
       source: 'web-client',
-      level: 'info',
+      level,
       message: line,
       context: {
         userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : '',


### PR DESCRIPTION
## 概要

クライアントの `log()` が Hub (`/api/client-events`) へ送るログを、これまでの「`通知` で始まるメッセージのみ」から **全ログ** に拡張する。

## 背景

従来は `通知` 始まりのログだけを Hub へ転送していたため、G2 の startup 描画失敗・画面遷移・イベント系ログが PC 側に届かず、待機/一覧まわりの不具合の追跡ができなかった。

## 変更点

- `src/log.ts`: `message.startsWith('通知')` のフィルタを撤廃し、全ログを Hub へミラー
- 失敗系メッセージ（`失敗|エラー|error|code=[1-3]`）は `level=error` でタグ付けし、Hub 側で絞り込みやすく

送信先は利用者が設定する `notificationHubUrl` のみ。未設定なら何も送信しない（従来どおり）。