### PR TITLE
Fix codex hooks feature flag: codex_hooks -> hooks

### DIFF
--- a/scripts/cc-g2.sh
+++ b/scripts/cc-g2.sh
@@ -953,7 +953,7 @@ if [ "$USE_NATIVE_CODEX" -eq 1 ]; then
     CC_G2_TMUX_TARGET="${CC_G2_TMUX_TARGET:-}"
   )
   CODEX_ARGS=(
-    --enable codex_hooks
+    --enable hooks
     -c "hooks=${CODEX_HOOKS_CONFIG}"
   )
   if [ "${#CLAUDE_ARGS[@]}" -gt 0 ]; then


### PR DESCRIPTION
The `codex_hooks` feature flag no longer exists in codex CLI (verified on 0.135.0 via `codex features list`).

The correct stable feature name is `hooks` (equivalent to `-c features.hooks=true`). The old name was a no-op on current codex, so hooks were silently not enabled.

- `--enable codex_hooks` → `--enable hooks`