### PR TITLE
Add cc-g2 --version and release script, bump to 0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wmoto-ai/cc-g2",
   "packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": false,
   "type": "module",
   "bin": {
@@ -35,7 +35,8 @@
     "preview": "vite preview",
     "test": "vitest run test/even-events.test.ts test/format-and-wav.test.ts test/paginate-text.test.ts test/hub-approval-api.test.mjs test/hub-hook-endpoint.test.mjs test/hub-codex-hook.test.mjs test/hub-location-api.test.mjs test/voice-entry.test.mjs",
     "test:all": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "release": "npm version patch && pnpm publish && git push --follow-tags && gh release create \"v$(node -p \"require('./package.json').version\")\" --generate-notes"
   },
   "dependencies": {
     "@evenrealities/even_hub_sdk": "^0.0.7",

--- a/scripts/cc-g2.sh
+++ b/scripts/cc-g2.sh
@@ -15,6 +15,7 @@
 #   cc-g2 --codex          # Codex CLI + G2
 #   cc-g2 --native-codex   # Codex CLI + G2 (互換 alias)
 #   cc-g2 --help           # ヘルプ表示
+#   cc-g2 --version        # バージョン表示
 #   cc-g2 !                # インフラ再起動してから Claude Code + G2
 #   cc-g2 stop             # G2 インフラ全停止
 #   cc-g2 status           # 状態確認
@@ -87,6 +88,7 @@ Options:
   --new            Force a new tmux session
   !                Restart Hub/Vite/Voice Entry before launch
   --help, -h       Show this help
+  --version, -v    Show cc-g2 version
 
 Environment:
   SHOW_QR=0        Hide QR code
@@ -837,6 +839,11 @@ case "${1:-}" in
   new|--new) FORCE_NEW_SESSION=1; shift ;;
   codex)   AGENT_MODE="codex"; shift; set -- --codex "$@" ;;
   --help|-h|help) print_usage; exit 0 ;;
+  --version|-v|version)
+    ver="$(node -p "require('${G2_PROJECT_DIR}/package.json').version" 2>/dev/null \
+      || sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${G2_PROJECT_DIR}/package.json" | head -1)"
+    echo "cc-g2 ${ver:-unknown}"
+    exit 0 ;;
   stop)    cmd_stop; exit 0 ;;
   status)  cmd_status; exit 0 ;;
   doctor)  cmd_doctor; exit 0 ;;


### PR DESCRIPTION
## What

- `cc-g2 --version` / `-v` now prints the version, read from `package.json` (node with a `sed` fallback).
- Add a `release` npm script: `npm version patch` + `pnpm publish` + tag push + `gh release create --generate-notes`, so future releases are a single `pnpm release`.
- Bump 0.1.4 -> 0.1.5.

## Why

The published `0.1.4` was frozen since late April while many fixes (codex hooks flag, AskUserQuestion long-text display, standby flash, log mirroring) landed unreleased. GitHub Packages refuses to overwrite an existing version, so a bump is required to ship them. This release unsticks that and gives a repeatable release flow.