### PR TITLE
Make cc-g2 --version/--help work without tmux, bump to 0.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wmoto-ai/cc-g2",
   "packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": false,
   "type": "module",
   "bin": {

--- a/scripts/cc-g2.sh
+++ b/scripts/cc-g2.sh
@@ -507,6 +507,17 @@ check_deps() {
     warn "tailscale が見つかりません（QRコード表示に必要。SHOW_QR=0 で省略可）"
   fi
 }
+
+# --version / --help は依存チェックより前に処理（tmux などが無くても確認できるように）
+case "${1:-}" in
+  --version|-v|version)
+    ver="$(node -p "require('${G2_PROJECT_DIR}/package.json').version" 2>/dev/null \
+      || sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${G2_PROJECT_DIR}/package.json" | head -1)"
+    echo "cc-g2 ${ver:-unknown}"
+    exit 0 ;;
+  --help|-h|help)
+    print_usage; exit 0 ;;
+esac
 check_deps
 CLAUDE_BIN="$(resolve_claude_bin)"
 CODEX_BIN="$(resolve_codex_bin)"
@@ -838,12 +849,6 @@ run_internal_command "${1:-}" "${@:2}"
 case "${1:-}" in
   new|--new) FORCE_NEW_SESSION=1; shift ;;
   codex)   AGENT_MODE="codex"; shift; set -- --codex "$@" ;;
-  --help|-h|help) print_usage; exit 0 ;;
-  --version|-v|version)
-    ver="$(node -p "require('${G2_PROJECT_DIR}/package.json').version" 2>/dev/null \
-      || sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${G2_PROJECT_DIR}/package.json" | head -1)"
-    echo "cc-g2 ${ver:-unknown}"
-    exit 0 ;;
   stop)    cmd_stop; exit 0 ;;
   status)  cmd_status; exit 0 ;;
   doctor)  cmd_doctor; exit 0 ;;


### PR DESCRIPTION
## What

Move `--version`/`-v` and `--help` handling **before** the `check_deps` dependency check, so version and usage can be queried even on machines without tmux/lsof installed yet.

## Why

On a fresh install (e.g. a new Mac before `brew install tmux`), `cc-g2 --version` aborted with `必須コマンドが見つかりません: tmux` because `check_deps` ran first. Querying version/help shouldn't require the full runtime toolchain.

Bump 0.1.5 -> 0.1.6.