### PR TITLE
承認コメントのキーワードマッチを廃止し常にdeny+commentで解決

### DIFF
--- a/server/notification-hub/index.mjs
+++ b/server/notification-hub/index.mjs
@@ -1232,43 +1232,18 @@ const server = createServer(async (req, res) => {
           log(`ask-user-question answered id=${linkedApproval.id} answers=${JSON.stringify(answerData)}`)
           shouldRelay = false
         }
-        // Resolve approval: explicit approve/deny actions, or parse comment text
-        let resolvedAction = null
+        // Resolve approval: approve/deny ボタンはそのまま、comment は常に deny+comment
         if (action === 'answer') {
           // already handled above
         } else if (action === 'approve' || action === 'deny') {
-          resolvedAction = action
-        } else if (action === 'comment' || !action) {
-          // G2 sends comments (not explicit approve/deny buttons).
-          // Parse comment text for intent keywords. If no keyword matches,
-          // do NOT resolve the approval — let the comment be relayed as plain text
-          // to the Claude Code input. Explicit approve/deny buttons should be used
-          // for approval decisions.
-          const text = (comment || replyText || '').toLowerCase().trim()
-          const denyPatterns = ['拒否', 'deny', 'no', 'reject', 'だめ', 'ダメ', 'いいえ']
-          const approvePatterns = ['承認', 'approve', 'yes', 'ok', 'おk', 'いいよ', 'はい', '許可']
-          if (denyPatterns.some((p) => text.includes(p))) {
-            resolvedAction = 'deny'
-          } else if (approvePatterns.some((p) => text.includes(p))) {
-            resolvedAction = 'approve'
-          }
-          // else: no keyword match → resolvedAction stays null → approval not resolved
-          // comment is still relayed to tmux as plain text input
-        }
-        if (resolvedAction) {
-          record.resolvedAction = resolvedAction
+          record.resolvedAction = action
           record.result = 'resolved'
-          resolveApproval(linkedApproval.id, resolvedAction, comment, source || 'g2')
+          resolveApproval(linkedApproval.id, action, comment, source || 'g2')
           log(
-            `approval-broker resolved id=${linkedApproval.id} action=${resolvedAction} (original=${action || 'none'} text=${(comment || replyText || '').slice(0, 50)})`,
+            `approval-broker resolved id=${linkedApproval.id} action=${action} text=${(comment || replyText || '').slice(0, 50)}`,
           )
-          // HTTP hook が承認を解決済みなので tmux relay は不要。
-          // relay すると承認ダイアログ消失後に y/n キーが入力欄に漏れる。
           shouldRelay = false
-        } else if (action === 'comment') {
-          // Comment without keyword match on an approval notification:
-          // HTTP hook 経由の場合は deny + comment として approval を解決し、
-          // HTTP レスポンスで Claude Code に返す。tmux relay は不要。
+        } else if (action === 'comment' || !action) {
           const commentText = comment || replyText || ''
           record.resolvedAction = 'deny'
           record.result = 'resolved'

--- a/test/hub-approval-api.test.mjs
+++ b/test/hub-approval-api.test.mjs
@@ -254,6 +254,24 @@ describe('Notification Hub — Approval Broker API', () => {
     expect(approvalData.approval.comment).toBe('LGTM')
   })
 
+  it('G2 voice comment on approval always resolves as deny+comment', async () => {
+    const created = await createTestApproval({ toolName: 'CommentDeny' })
+
+    const { status, data } = await postJson(
+      hubBase,
+      `/api/notifications/${created.notificationId}/reply`,
+      { action: 'comment', comment: '書かなくていいよ', source: 'g2' },
+    )
+    expect(status).toBe(200)
+    expect(data.reply.resolvedAction).toBe('deny')
+    expect(data.reply.result).toBe('resolved')
+
+    const { data: approvalData } = await getJson(hubBase, `/api/approvals/${created.approvalId}`)
+    expect(approvalData.approval.status).toBe('decided')
+    expect(approvalData.approval.decision).toBe('deny')
+    expect(approvalData.approval.comment).toBe('書かなくていいよ')
+  })
+
   it('POST /api/notifications/:id/reply — rejects unauthenticated requests when token is enabled', async () => {
     const created = await createTestApproval({ toolName: 'ReplyAuth' })
     const res = await fetch(`${hubBase}/api/notifications/${created.notificationId}/reply`, {


### PR DESCRIPTION
## Summary
- コメントボタン（`action=comment`）経由のリプライで走っていたキーワードマッチング（「いいよ」「はい」→approve）を完全に削除
- `comment` および `action`未指定は常に deny + comment で解決
- 日本語の否定表現を含むコメントが誤って approve に解決されるバグを修正
- 回帰テストを追加

## Changes
- `server/notification-hub/index.mjs`: キーワードマッチロジック削除、comment/action未指定→常にdeny+comment
- `test/hub-approval-api.test.mjs`: 回帰テスト追加（「書かなくていいよ」がdenyになることを検証）