### PR TITLE
Update Soniox realtime STT model

### DIFF
--- a/src/stt/soniox-realtime.ts
+++ b/src/stt/soniox-realtime.ts
@@ -69,7 +69,7 @@ export class SonioxRealtimeSTT {
         log('Soniox Realtime: WebSocket connected, sending config...')
         ws.send(JSON.stringify({
           api_key: apiKey,
-          model: 'stt-rt-v4',
+          model: 'stt-rt-v5',
           audio_format: 'pcm_s16le',
           sample_rate: 16000,
           num_channels: 1,
@@ -328,7 +328,7 @@ export class SonioxRealtimeSTT {
     return {
       text,
       provider: 'soniox',
-      model: 'stt-rt-v4',
+      model: 'stt-rt-v5',
     }
   }
 


### PR DESCRIPTION
## Summary

- Update the Soniox realtime STT model from `stt-rt-v4` to `stt-rt-v5`.
- Keep the returned STT model label aligned with the request model.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm test`