### PR TITLE
Remove esbuild release-age exception

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,4 @@
 minimumReleaseAge: 10080
-minimumReleaseAgeExclude:
-  - esbuild
-  - '@esbuild/*'
 
 packages:
   - .


### PR DESCRIPTION
## Summary
- Remove the temporary pnpm minimumReleaseAgeExclude entries for esbuild and @esbuild/* now that esbuild@0.28.1 has passed the 7-day age gate

## Verification
- pnpm install --lockfile-only