### PR TITLE
security: dependabot cooldown + CI permissions 最小化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# Supply chain hardening: version updates with cooldown.
+# Security updates は別系統(account-level で有効済み)で cooldown の影響を受けない。
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+      semver-patch-days: 3
+      semver-major-days: 30
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,5 +1,8 @@
 name: Dependency Review
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:


### PR DESCRIPTION
## 概要

サプライチェーン防御の横展開 (2026-07 hardening)。

- **`.github/dependabot.yml` 追加**: version updates に cooldown(patch 3日 / minor 7日 / major 30日)+ グループ化 + monthly スケジュール。
  - なぜ: 2025-26 の npm/PyPI 攻撃(chalk/debug 型、Shai-Hulud 型ワーム)では悪性版が公開後数時間〜数日で削除された。新バージョンを寝かせるだけで大半を回避できる。
  - security updates(account-level で有効済み)は cooldown の影響を受けず即時のまま。
  - `github-actions` エントリは SHA ピンの追従更新用(ピン留めは既に完了済みと確認)。
- 該当 repo のみ: read-only workflow に `permissions: contents: read` を明示(GITHUB_TOKEN 悪用時の影響半径を最小化)。

設計全文: research-notes `2026-07-06-supply-chain-security-automation.md`

Generated with Claude Code
